### PR TITLE
Simplify configuration for set-window

### DIFF
--- a/configuration.org
+++ b/configuration.org
@@ -90,12 +90,12 @@
   (use-package switch-window
     :ensure t
     :config
-    (setq switch-window-input-style 'minibuffer)
-    (setq switch-window-increase 4)
-    (setq switch-window-threshold 2)
-    (setq switch-window-shortcut-style 'qwerty)
-    (setq switch-window-qwerty-shortcuts
-	  '("a" "s" "d" "f" "j" "k" "l"))
+    (setq switch-window-input-style 'minibuffer
+          switch-window-increase 4
+          switch-window-threshold 2
+          switch-window-shortcut-style 'qwerty
+          switch-window-qwerty-shortcuts
+	            '("a" "s" "d" "f" "j" "k" "l"))
     :bind
     ([remap other-window] . switch-window))
 #+END_SRC


### PR DESCRIPTION
The function setq accepts multiple pairs of symbols and values and can therefore
be simplified.